### PR TITLE
Agrega traduccion via yandex.

### DIFF
--- a/client.js
+++ b/client.js
@@ -2,15 +2,31 @@ var shoe = require('shoe');
 var meSpeak = require('mespeak');
 var Writable = require('stream').Writable
 var ws = Writable()
-
-ws._write = function (chunk, enc, next) {
-  meSpeak.speak(chunk, {}, cb)
-  function cb () { return next() }
+var log = Writable()
+var langs = {
+  es: require('mespeak/voices/es-la.json'),
+  en: require('mespeak/voices/en/en.json'),
+  de: require('mespeak/voices/de.json'),
+  fr: require('mespeak/voices/fr.json'),
+  it: require('mespeak/voices/it.json')
 }
-meSpeak.loadVoice(require('mespeak/voices/es-la.json'));
 meSpeak.loadConfig(require('mespeak/src/mespeak_config.json'));
 
+
+log._write = function (chunk, enc, next) {
+  var data = chunk.toString().split(',')
+  console.log('mensaje: ' + data[0].toString() + ' lang:  '  + data[1])
+  next()
+}
+
+ws._write = function (chunk, enc, next) {
+  var data = chunk.toString().split(',')
+  meSpeak.loadVoice(langs[data[1]], speak)
+  function speak (loaded, voice) {meSpeak.speak(' ' + data[0].toString(), {voice: voice}, cb)
+  function cb () { return next() }
+  }
+}
 var sock = shoe('/nas');
 
-// sock.on('data', function (datum) { meSpeak.speak(datum)});
 sock.pipe(ws)
+sock.pipe(log)

--- a/index.js
+++ b/index.js
@@ -1,11 +1,26 @@
 var shoe = require('shoe')
 var http = require('http')
 var ecstatic = require('ecstatic')(__dirname + '/static')
+var tr = require('yandex-translate')('trnsl.1.1.20150918T221751Z.720a41963ee12318.6000ac0baa6b918e812737129e723190d984d4de')
+var ms = require('map-stream')
+
+var translate = ms(function (data, callback) {
+  if (!data) callback()
+  data = data.toString().slice(0, -1).split('  ')
+  if (!data[1]) callback(null, [data[0], 'es'].toString())
+  tr.translate(data[0], {from: 'es', to: data[1]}, function (err, res) {
+    if (err) return callback(err)
+    callback(null, [res.text, data[1]].toString())
+  })
+})
+
+var translated = process.stdin.pipe(translate)
+
 
 var server = http.createServer(ecstatic)
 server.listen(9999)
 
 var sock = shoe(function(stream) {
-  process.stdin.pipe(stream)
+  translated.pipe(stream)
 })
 sock.install(server, '/nas')

--- a/package.json
+++ b/package.json
@@ -22,7 +22,9 @@
   "homepage": "https://github.com/santiagogil/nas#readme",
   "dependencies": {
     "ecstatic": "^1.0.0",
+    "map-stream": "0.0.6",
     "mespeak": "^2.0.0",
-    "shoe": "0.0.15"
+    "shoe": "0.0.15",
+    "yandex-translate": "^2.0.2"
   }
 }


### PR DESCRIPTION
El servidor realiza la request a la api de yandex translate y envia el
resultado al navegador.

Uso: mensaje a traducir<  >fr
Se tipea el mensaje, seguido por dos espacios y la sigla del idioma de
destino.
